### PR TITLE
1.21.5 support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency properties
-minestomVersion=ebaa2bbf64
+minestomVersion=1_21_5-163b6b668d
 # Gradle properties
 #
 # Enables configure on demand (incubating feature)

--- a/src/main/java/eu/koboo/minestom/stomui/api/ViewBuilder.java
+++ b/src/main/java/eu/koboo/minestom/stomui/api/ViewBuilder.java
@@ -12,7 +12,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.inventory.InventoryPreClickEvent;
 import net.minestom.server.inventory.Inventory;
-import net.minestom.server.inventory.click.ClickType;
+import net.minestom.server.inventory.click.Click;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
@@ -30,7 +30,7 @@ public final class ViewBuilder {
 
     final ViewType type;
     final Set<Flag> flags;
-    final Set<ClickType> disabledClickTypes;
+    final Set<Class<? extends Click>> disabledClickTypes;
     ViewProvider provider;
     Component title;
     int clickCooldownInMillis;
@@ -122,14 +122,15 @@ public final class ViewBuilder {
     }
 
     /**
-     * Adds the given {@link ClickType}s as disabled/cancelled, which results in
-     * ignoring any {@link Interaction} if the specific {@link ClickType} is used
+     * Adds the given {@link Click}s as disabled/cancelled, which results in
+     * ignoring any {@link Interaction} if the specific {@link Click} is used
      * and just cancelling the {@link InventoryPreClickEvent}.
      *
-     * @param clickTypes The {@link ClickType}s, which will be cancelled.
+     * @param clickTypes The {@link Click}s, which will be cancelled.
      * @return This {@link ViewBuilder} instance.
      */
-    public @NotNull ViewBuilder disableClickTypes(@NotNull ClickType... clickTypes) {
+    @SafeVarargs
+    public final @NotNull ViewBuilder disableClickTypes(@NotNull Class<? extends Click>... clickTypes) {
         this.disabledClickTypes.addAll(List.of(clickTypes));
         return this;
     }

--- a/src/main/java/eu/koboo/minestom/stomui/api/item/ModifiableItem.java
+++ b/src/main/java/eu/koboo/minestom/stomui/api/item/ModifiableItem.java
@@ -7,15 +7,16 @@ import lombok.experimental.FieldDefaults;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minestom.server.component.DataComponent;
-import net.minestom.server.item.ItemComponent;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.utils.Unit;
+import net.minestom.server.item.component.TooltipDisplay;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * This abstract class represents a {@link PrebuiltItem} or a {@link ViewItem}
@@ -90,7 +91,7 @@ public abstract sealed class ModifiableItem permits PrebuiltItem, ViewItem {
     public <T extends ModifiableItem> T loreLine(int lineIndex, @Nullable Component component) {
         ItemStack itemStack = getItem();
         List<Component> newComponentList = new ArrayList<>();
-        List<Component> loreComponentList = itemStack.get(ItemComponent.LORE);
+        List<Component> loreComponentList = itemStack.get(DataComponents.LORE);
         if (loreComponentList != null) {
             newComponentList.addAll(loreComponentList);
         }
@@ -140,7 +141,7 @@ public abstract sealed class ModifiableItem permits PrebuiltItem, ViewItem {
     }
 
     public <T extends ModifiableItem> T glint(boolean isGlint) {
-        return addComponent(ItemComponent.ENCHANTMENT_GLINT_OVERRIDE, isGlint);
+        return addComponent(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, isGlint);
     }
 
     public <T extends ModifiableItem> T glint() {
@@ -152,15 +153,29 @@ public abstract sealed class ModifiableItem permits PrebuiltItem, ViewItem {
     }
 
     public boolean hasGlint() {
-        return hasComponentValue(ItemComponent.ENCHANTMENT_GLINT_OVERRIDE, true);
+        return hasComponentValue(DataComponents.ENCHANTMENT_GLINT_OVERRIDE, true);
     }
 
     public <T extends ModifiableItem> T hideTooltip(boolean hide) {
         T ret;
         if (hide) {
-            ret = addComponent(ItemComponent.HIDE_TOOLTIP, Unit.INSTANCE);
+            ret = addComponent(DataComponents.TOOLTIP_DISPLAY, new TooltipDisplay(true, Set.of(
+                DataComponents.BANNER_PATTERNS, DataComponents.BEES, DataComponents.BLOCK_ENTITY_DATA,
+                DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS, DataComponents.CHARGED_PROJECTILES,
+                DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
+                DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
+                DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
+                DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT
+            )));
         } else {
-            ret = removeComponent(ItemComponent.HIDE_TOOLTIP);
+            ret = addComponent(DataComponents.TOOLTIP_DISPLAY, new TooltipDisplay(false, Set.of(
+                DataComponents.BANNER_PATTERNS, DataComponents.BEES, DataComponents.BLOCK_ENTITY_DATA,
+                DataComponents.BLOCK_STATE, DataComponents.BUNDLE_CONTENTS, DataComponents.CHARGED_PROJECTILES,
+                DataComponents.CONTAINER, DataComponents.CONTAINER_LOOT, DataComponents.FIREWORK_EXPLOSION,
+                DataComponents.FIREWORKS, DataComponents.INSTRUMENT, DataComponents.MAP_ID,
+                DataComponents.PAINTING_VARIANT, DataComponents.POT_DECORATIONS, DataComponents.POTION_CONTENTS,
+                DataComponents.TROPICAL_FISH_PATTERN, DataComponents.WRITTEN_BOOK_CONTENT
+            )));
         }
         return ret;
     }

--- a/src/main/java/eu/koboo/minestom/stomui/core/CorePlayerView.java
+++ b/src/main/java/eu/koboo/minestom/stomui/core/CorePlayerView.java
@@ -19,7 +19,7 @@ import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.minestom.server.entity.Player;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.PlayerInventory;
-import net.minestom.server.inventory.click.ClickType;
+import net.minestom.server.inventory.click.Click;
 import net.minestom.server.item.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -44,7 +44,7 @@ public final class CorePlayerView implements PlayerView {
     final ViewProvider provider;
     final Map<Integer, Interaction> interactions;
     final Set<Flag> addedFlags;
-    final Set<ClickType> disabledClickTypes;
+    final Set<Class<? extends Click>> disabledClickTypes;
 
     final long clickCooldown;
     final long slotClickCooldown;

--- a/src/main/java/eu/koboo/minestom/stomui/core/listener/ViewInventoryPreClickListener.java
+++ b/src/main/java/eu/koboo/minestom/stomui/core/listener/ViewInventoryPreClickListener.java
@@ -85,7 +85,7 @@ public final class ViewInventoryPreClickListener implements Consumer<InventoryPr
             }
         }
 
-        if (playerView.getDisabledClickTypes().contains(event.getClickType())) {
+        if (playerView.getDisabledClickTypes().contains(event.getClick().getClass())) {
             event.setCancelled(true);
             return;
         }


### PR DESCRIPTION
This PR adds support for 1.21.5 and the item and inventory click improvements. It is compiled against the latest commit on the 1.21.5 branch.

First, it replaces uses of the `ItemComponents` class with `DataComponents` class.
Additionally, it replaces the use of the `ClickType` enum, in favor of Golden's inventory rework. Instead it checks if the click class is disabled instead of the click type. 
